### PR TITLE
Resizable Panes

### DIFF
--- a/static/panes.less
+++ b/static/panes.less
@@ -4,30 +4,39 @@
 // settings-view, the archive-view, the image-view. Etc. Basically a non-
 // editor resource with a tab.
 atom-pane-container {
+  position: relative;
   display: -webkit-flex;
   -webkit-flex: 1;
 
-  atom-pane-axis.vertical {
+  atom-pane-axis {
     display: -webkit-flex;
     -webkit-flex: 1;
+
+    & > atom-pane-resize-handle {
+      position: absolute;
+      z-index: 3;
+    }
+  }
+
+  atom-pane-axis.vertical {
     -webkit-flex-direction: column;
 
     & > atom-pane-resize-handle {
+      width: 100%;
       height: 8px;
-      z-index: 3;
+      margin-top: -4px;
       cursor: ns-resize;
       border-bottom: none;
     }
   }
 
   atom-pane-axis.horizontal {
-    display: -webkit-flex;
-    -webkit-flex: 1;
     -webkit-flex-direction: row;
 
     & > atom-pane-resize-handle {
       width: 8px;
-      z-index: 3;
+      height: 100%;
+      margin-left: -4px;
       cursor: ew-resize;
       border-right: none;
     }


### PR DESCRIPTION
This PR is on top of https://github.com/atom/atom/pull/5902.
- It absolute positions the pane resize-handles so they don't take up space and instead overlap the editors.
- It keeps most themes unaffected
- It's more consistent with the tree-view resizer

Before:

![screen shot 2015-03-17 at 4 19 32 pm](https://cloud.githubusercontent.com/assets/378023/6682850/775da002-ccc1-11e4-8707-143abfbd7f13.png)

After:

![resize-pane](https://cloud.githubusercontent.com/assets/378023/6682869/9ec94c40-ccc1-11e4-8920-f223af7b460b.gif)

Themes could still override the `atom-pane-resize-handle` to be relative, if they prefer.
